### PR TITLE
Add offen/offen repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Other CLI templates
 - [choo-ban](https://github.com/luizbaldi/choo-ban) - Simple kanban to manage board tasks, built with `choo`.
 - [boowa](https://github.com/boowajs/boowa) - A fun blog generator, built with `choo`.
 - [hyperamp](https://github.com/hypermodules/hyperamp) - Humble music player.
+- [offen](https://github.com/offen/offen) - self hosted, fair web analytics
 
 ### License
 


### PR DESCRIPTION
[offen](https://github.com/offen/offen) uses choo for building the majority of its frontend.

---

Disclaimer: I run this project.